### PR TITLE
Relaquery: ajout de fonctions de tests unitaires

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -60,7 +60,7 @@ async def write_result(new_result: ResultIn = Depends()):
     season = "S" if new_result["season"] == "Summer" else "W"
     count_query = f"SELECT COUNT(id) FROM result WHERE games LIKE '{season}%'"
     n_results = await database.execute(count_query)
-    new_result_id = "".join([season, str(n_results).zfill(6)])
+    new_result_id = "".join([season, str(n_results+1).zfill(6)])
     new_result_games = give_games_id(new_result["year"],
                                      new_result["season"])
 

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -30,3 +30,34 @@ def test_get_a_result(input_id, expected):
         response = client.get(f"/result/{input_id}")
         assert response.status_code == 200
         assert response.json() == expected
+
+
+@pytest.mark.parametrize(
+        ("input_post", "expected"),
+        (
+            ({
+                "season": "Winter",
+                "year": "2014",
+                "sport": "Ice Swimming",
+                "event": "Ice Swimming Women's 200m Butterfly",
+                "athlete": "410421217148",
+                "noc": "HUN",
+                "medal": "S"
+              },
+             {
+                "id": "W048565",
+                "games": "W2014",
+                "sport": "Ice Swimming",
+                "event": "Ice Swimming Women's 200m Butterfly",
+                "athlete": "410421217148",
+                "noc": "HUN",
+                "medal": "S"
+              }),
+        )
+)
+def test_write_a_result(input_post, expected):
+    with TestClient(app) as client:
+        response = client.post("/result/new", params=input_post)
+        assert response.status_code == 200
+        assert response.json() == expected
+        client.delete(f"/result/{response.json()['id']}")

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -98,3 +98,14 @@ def test_update_a_result(input_id, input_update, expected):
         assert response.json() == expected
         # On rétablit les valeurs modifiées pour le test à leur état d'origine
         client.put(f"/result/{input_id}", params=original_input)
+
+def test_delete_a_result():
+    test_item_input = zjakabos_ice_swimming_input
+    with TestClient(app) as client:
+        create_test_item = client.post("/result/new", params=test_item_input)
+        assert create_test_item.status_code == 200
+        test_item = create_test_item.json()
+        response = client.delete(f"/result/{test_item['id']}")
+        assert response.status_code == 200
+        assert response.json() == {"message": f"Deleted {test_item['id']}."}
+        #assert client.get(f"/result/{test_item['id']}") == 404

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -8,45 +8,45 @@ import pytest
 # EXEMPLES #
 
 # Result
-lmanaudou2004_swim = {
-                        "id": "S121453",
-                        "games": "S2004",
-                        "sport": "Swimming",
-                        "event": "Swimming Women's 400 metres Freestyle",
-                        "athlete": "506160875731",
-                        "noc": "FRA",
-                        "medal": "G"
+lmanaudou2004_400m = {
+    "id": "S121453",
+    "games": "S2004",
+    "sport": "Swimming",
+    "event": "Swimming Women's 400 metres Freestyle",
+    "athlete": "506160875731",
+    "noc": "FRA",
+    "medal": "G"
                       }
 
-lmanaudou2004_boxing = {
-                        "id": "S121453",
-                        "games": "S2004",
-                        "sport": "Boxing",
-                        "event": "Swimming Women's 400 metres Freestyle",
-                        "athlete": "506160875731",
-                        "noc": "FRA",
-                        "medal": "G"
-                      }
+lmanaudou2012_400m_input = {
+    "season": "Summer",
+    "year": "2012",
+    "sport": "Swimming",
+    "event": "Swimming Women's 400 metres Freestyle",
+    "athlete": "506160875731",
+    "noc": "FRA",
+    "medal": "G"
+                            }
 
-zjakabos_ice_swimming_input = {
-                                "season": "Winter",
-                                "year": "2014",
-                                "sport": "Ice Swimming",
-                                "event": "Ice Swimming Women's 200m Butterfly",
-                                "athlete": "410421217148",
-                                "noc": "HUN",
-                                "medal": "S"
-                                }
+lmanaudou2012_400m_output = {
+    "id": "S237674",
+    "games": "S2012",
+    "sport": "Swimming",
+    "event": "Swimming Women's 400 metres Freestyle",
+    "athlete": "506160875731",
+    "noc": "FRA",
+    "medal": "G"
+                             }
 
-zjakabos_ice_swimming_output = {
-                                "id": "W048565",
-                                "games": "W2014",
-                                "sport": "Ice Swimming",
-                                "event": "Ice Swimming Women's 200m Butterfly",
-                                "athlete": "410421217148",
-                                "noc": "HUN",
-                                "medal": "S"
-                                }
+lmanaudou2012_boxing = {
+    "id": "S237674",
+    "games": "S2012",
+    "sport": "Boxing",
+    "event": "Swimming Women's 400 metres Freestyle",
+    "athlete": "506160875731",
+    "noc": "FRA",
+    "medal": "G"
+                        }
 
 
 def test_greetings():
@@ -58,7 +58,7 @@ def test_greetings():
 @pytest.mark.parametrize(
     ("input_id", "expected"),
     (
-        (lmanaudou2004_swim["id"], lmanaudou2004_swim),
+        (lmanaudou2004_400m["id"], lmanaudou2004_400m),
     )
 )
 def test_get_a_result(input_id, expected):
@@ -71,7 +71,7 @@ def test_get_a_result(input_id, expected):
 @pytest.mark.parametrize(
         ("input_post", "expected"),
         (
-            (zjakabos_ice_swimming_input, zjakabos_ice_swimming_output),
+            (lmanaudou2012_400m_input, lmanaudou2012_400m_output),
         )
 )
 def test_write_a_result(input_post, expected):
@@ -83,24 +83,28 @@ def test_write_a_result(input_post, expected):
         client.delete(f"/result/{response.json()['id']}")
 
 @pytest.mark.parametrize(
-        ("input_id", "input_update", "expected"),
+        ("test_input", "update_params", "expected"),
         (
-            (lmanaudou2004_swim["id"],
+            (lmanaudou2012_400m_input,
              {"sport": "Boxing"},
-             lmanaudou2004_boxing),
+             lmanaudou2012_boxing),
         )
 )
-def test_update_a_result(input_id, input_update, expected):
+def test_update_a_result(test_input, update_params, expected):
     with TestClient(app) as client:
-        original_input = client.get(f"/result/{input_id}").json()
-        response = client.put(f"/result/{input_id}", params=input_update)
+        create_test_item = client.post("/result/new/", params=test_input)
+        assert create_test_item.status_code == 200
+        test_item = create_test_item.json()
+        response = client.put(f"/result/{test_item['id']}",
+                              params=update_params)
         assert response.status_code == 200
         assert response.json() == expected
-        # On rétablit les valeurs modifiées pour le test à leur état d'origine
-        client.put(f"/result/{input_id}", params=original_input)
+        # On supprime l'entrée créée pour le test
+        client.delete(f"/result/{test_item['id']}")
+
 
 def test_delete_a_result():
-    test_item_input = zjakabos_ice_swimming_input
+    test_item_input = lmanaudou2012_400m_input
     with TestClient(app) as client:
         create_test_item = client.post("/result/new", params=test_item_input)
         assert create_test_item.status_code == 200
@@ -108,4 +112,4 @@ def test_delete_a_result():
         response = client.delete(f"/result/{test_item['id']}")
         assert response.status_code == 200
         assert response.json() == {"message": f"Deleted {test_item['id']}."}
-        #assert client.get(f"/result/{test_item['id']}") == 404
+        assert client.get(f"/result/{test_item['id']}").status_code == 404

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -48,6 +48,31 @@ lmanaudou2012_boxing = {
     "medal": "G"
                         }
 
+tparker = {
+    "id": "715210719562",
+    "first_name": "William",
+    "last_name": "PARKER",
+    "gender": "M",
+    "birth_year": 1982,
+    "lattest_noc": "FRA"
+}
+
+vwembanyama_input = {
+    "first_name": "Victor",
+    "last_name": "Wembanyama",
+    "gender": "M",
+    "birth_year": 2004,
+    "lattest_noc": "FRA",
+}
+
+vwembanyama_output = {
+    "id": "076466741491",
+    "first_name": "Victor",
+    "last_name": "WEMBANYAMA",
+    "gender": "M",
+    "birth_year": 2004,
+    "lattest_noc": "FRA"
+}
 
 def test_greetings():
     with TestClient(app) as client:
@@ -113,3 +138,29 @@ def test_delete_a_result():
         assert response.status_code == 200
         assert response.json() == {"message": f"Deleted {test_item['id']}."}
         assert client.get(f"/result/{test_item['id']}").status_code == 404
+
+@pytest.mark.parametrize(
+        ("input_id", "expected"),
+        (
+            (tparker["id"], tparker),
+        )
+)
+def test_get_an_athlete(input_id, expected):
+    with TestClient(app) as client:
+        response = client.get(f"/athlete/{input_id}")
+        assert response.status_code == 200
+        assert response.json() == expected
+
+@pytest.mark.parametrize(
+        ("input_post", "expected"),
+        (
+            (vwembanyama_input, vwembanyama_output),
+        )
+)
+def test_write_an_athlete(input_post, expected):
+    with TestClient(app) as client:
+        response = client.post("/athlete/new", params=input_post)
+        assert response.status_code == 200
+        assert response.json() == expected
+        # On supprime l'entrée créée pour le test
+        client.delete(f"/athlete/{response.json()['id']}")

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -5,6 +5,50 @@ from fastapi.testclient import TestClient
 from app.api import app
 import pytest
 
+# EXEMPLES #
+
+# Result
+lmanaudou2004_swim = {
+                        "id": "S121453",
+                        "games": "S2004",
+                        "sport": "Swimming",
+                        "event": "Swimming Women's 400 metres Freestyle",
+                        "athlete": "506160875731",
+                        "noc": "FRA",
+                        "medal": "G"
+                      }
+
+lmanaudou2004_boxing = {
+                        "id": "S121453",
+                        "games": "S2004",
+                        "sport": "Boxing",
+                        "event": "Swimming Women's 400 metres Freestyle",
+                        "athlete": "506160875731",
+                        "noc": "FRA",
+                        "medal": "G"
+                      }
+
+zjakabos_ice_swimming_input = {
+                                "season": "Winter",
+                                "year": "2014",
+                                "sport": "Ice Swimming",
+                                "event": "Ice Swimming Women's 200m Butterfly",
+                                "athlete": "410421217148",
+                                "noc": "HUN",
+                                "medal": "S"
+                                }
+
+zjakabos_ice_swimming_output = {
+                                "id": "W048565",
+                                "games": "W2014",
+                                "sport": "Ice Swimming",
+                                "event": "Ice Swimming Women's 200m Butterfly",
+                                "athlete": "410421217148",
+                                "noc": "HUN",
+                                "medal": "S"
+                                }
+
+
 def test_greetings():
     with TestClient(app) as client:
         response = client.get("/")
@@ -14,15 +58,7 @@ def test_greetings():
 @pytest.mark.parametrize(
     ("input_id", "expected"),
     (
-        ("S121453", {
-                        "id": "S121453",
-                        "games": "S2004",
-                        "sport": "Swimming",
-                        "event": "Swimming Women's 400 metres Freestyle",
-                        "athlete": "506160875731",
-                        "noc": "FRA",
-                        "medal": "G"
-                    }),
+        (lmanaudou2004_swim["id"], lmanaudou2004_swim),
     )
 )
 def test_get_a_result(input_id, expected):
@@ -35,24 +71,7 @@ def test_get_a_result(input_id, expected):
 @pytest.mark.parametrize(
         ("input_post", "expected"),
         (
-            ({
-                "season": "Winter",
-                "year": "2014",
-                "sport": "Ice Swimming",
-                "event": "Ice Swimming Women's 200m Butterfly",
-                "athlete": "410421217148",
-                "noc": "HUN",
-                "medal": "S"
-              },
-             {
-                "id": "W048565",
-                "games": "W2014",
-                "sport": "Ice Swimming",
-                "event": "Ice Swimming Women's 200m Butterfly",
-                "athlete": "410421217148",
-                "noc": "HUN",
-                "medal": "S"
-              }),
+            (zjakabos_ice_swimming_input, zjakabos_ice_swimming_output),
         )
 )
 def test_write_a_result(input_post, expected):
@@ -60,4 +79,22 @@ def test_write_a_result(input_post, expected):
         response = client.post("/result/new", params=input_post)
         assert response.status_code == 200
         assert response.json() == expected
+        # On supprime l'entrée créée pour le test
         client.delete(f"/result/{response.json()['id']}")
+
+@pytest.mark.parametrize(
+        ("input_id", "input_update", "expected"),
+        (
+            (lmanaudou2004_swim["id"],
+             {"sport": "Boxing"},
+             lmanaudou2004_boxing),
+        )
+)
+def test_update_a_result(input_id, input_update, expected):
+    with TestClient(app) as client:
+        original_input = client.get(f"/result/{input_id}").json()
+        response = client.put(f"/result/{input_id}", params=input_update)
+        assert response.status_code == 200
+        assert response.json() == expected
+        # On rétablit les valeurs modifiées pour le test à leur état d'origine
+        client.put(f"/result/{input_id}", params=original_input)

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -3,10 +3,30 @@
 
 from fastapi.testclient import TestClient
 from app.api import app
-
-client = TestClient(app)
+import pytest
 
 def test_greetings():
-    response = client.get("/")
-    assert response.status_code == 200
-    assert response.json() == {"greetings": "Welcome to QUERYMPICS!"}
+    with TestClient(app) as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.json() == {"greetings": "Welcome to QUERYMPICS!"}
+
+@pytest.mark.parametrize(
+    ("input_id", "expected"),
+    (
+        ("S121453", {
+                        "id": "S121453",
+                        "games": "S2004",
+                        "sport": "Swimming",
+                        "event": "Swimming Women's 400 metres Freestyle",
+                        "athlete": "506160875731",
+                        "noc": "FRA",
+                        "medal": "G"
+                    }),
+    )
+)
+def test_get_a_result(input_id, expected):
+    with TestClient(app) as client:
+        response = client.get(f"/result/{input_id}")
+        assert response.status_code == 200
+        assert response.json() == expected

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -74,6 +74,15 @@ vwembanyama_output = {
     "lattest_noc": "FRA"
 }
 
+vwembanyama_usa = {
+    "id": "076466741491",
+    "first_name": "Victor",
+    "last_name": "WEMBANYAMA",
+    "gender": "M",
+    "birth_year": 2004,
+    "lattest_noc": "USA"
+}
+
 def test_greetings():
     with TestClient(app) as client:
         response = client.get("/")
@@ -164,3 +173,32 @@ def test_write_an_athlete(input_post, expected):
         assert response.json() == expected
         # On supprime l'entrée créée pour le test
         client.delete(f"/athlete/{response.json()['id']}")
+
+@pytest.mark.parametrize(
+        ("test_input", "update_params", "expected"),
+        (
+            (vwembanyama_input, {"lattest_noc": 'USA'}, vwembanyama_usa),
+        )
+)
+def test_update_an_athlete(test_input, update_params, expected):
+    with TestClient(app) as client:
+        create_test_item = client.post("/athlete/new/", params=test_input)
+        assert create_test_item.status_code == 200
+        test_item = create_test_item.json()
+        response = client.put(f"/athlete/{test_item['id']}",
+                              params=update_params)
+        assert response.status_code == 200
+        assert response.json() == expected
+        # On supprime l'entrée créée pour le test
+        client.delete(f"/athlete/{test_item['id']}")
+
+def test_delete_an_athlete():
+    test_item_input = vwembanyama_input
+    with TestClient(app) as client:
+        create_test_item = client.post("/athlete/new", params=test_item_input)
+        assert create_test_item.status_code == 200
+        test_item = create_test_item.json()
+        response = client.delete(f"/athlete/{test_item['id']}")
+        assert response.status_code == 200
+        assert response.json() == {"message": f"Deleted {test_item['id']}."}
+        assert client.get(f"/athlete/{test_item['id']}").status_code == 404


### PR DESCRIPTION
Ajouts de tests unitaires dans `test/api_test.py`
* Tests unitaires sur les fonctions CRUD pour les tables `result` & `athlete`
* Correction d'un bug sur la méthode `POST` de la table `result`